### PR TITLE
use secure URL

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -10,7 +10,7 @@ from flags import FLAGS
 from caniusepython3.pypi import all_py3_projects
 
 
-BASE_URL = 'http://pypi.python.org/pypi'
+BASE_URL = 'https://pypi.python.org/pypi'
 
 
 SESSION = requests.Session()


### PR DESCRIPTION
This only worked locally for me when using https to connect to PyPI. When using only http I would get a 403 response error.