### PR TITLE
Excluding marionette_client

### DIFF
--- a/src/flags.py
+++ b/src/flags.py
@@ -18,5 +18,6 @@ FLAGS = {
     "mozhttpd": "https://pypi.python.org/pypi/mozhttpd",
     "moztest": "https://pypi.python.org/pypi/moztest",
     "mozversion": "https://pypi.python.org/pypi/mozversion",
+    "marionette_client": "https://pypi.python.org/pypi/marionette_client",
     "marionette-transport": "https://pypi.python.org/pypi/marionette-transport",
 }


### PR DESCRIPTION
Like the other mozilla packages, it makes sense to exclude marionette_client.