### PR TITLE
Upgrade to use latest caniusepython3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+boto3
+caniusepython3
 requests
-caniusepython3 == 3.4.1

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,13 +1,13 @@
+import copy
 import datetime
 import json
-import copy
-import requests
 import xmlrpclib
 
-from caniusepython3.pypi import all_py3_projects
+import caniusepython3
+import requests
 
+from src.conf import BASE_URL, bucket, metadata, s3_client
 from src.flags import FLAGS
-from src.conf import bucket, s3_client, metadata, BASE_URL
 
 SESSION = requests.Session()
 
@@ -31,8 +31,6 @@ def req_rpc(method, *args):
 def get_json_url(package_name):
     return BASE_URL + '/' + package_name + '/json'
 
-py3_packages = all_py3_projects()
-
 
 def annotate_wheels(packages):
     print('Getting package data...')
@@ -41,7 +39,7 @@ def annotate_wheels(packages):
         print index + 1, num_packages, package['name']
 
         package['value'] = 1
-        if package['name'].lower() in py3_packages:
+        if caniusepython3.check(projects=[package['name']]):
             package['py3support'] = True
             package['css_class'] = 'success'
             package['icon'] = u'\u2713'  # Check mark
@@ -63,7 +61,7 @@ def remove_irrelevant_packages(packages, limit):
     print('Removing cruft...')
     added_limit = limit + len(FLAGS)
     packages = packages[:added_limit]
-    
+
     packages = [package for package in packages if package.get('name') not in FLAGS.keys()]
 
     return packages[:limit]


### PR DESCRIPTION
Fixes #48.

Rather than pinning to an older caniusepython3, update to use the latest 6.0.0.

This generates this JSON:


[results.json.txt](https://github.com/chhantyal/py3readiness/files/1829271/results.json.txt)


```console
⌂65% [hugo:~/github/py3readiness] [venv] fix-generate 5s ± python generate.py

Getting packages...
Removing cruft...
Getting package data...
1 360 simplejson
2 360 setuptools
3 360 six
4 360 requests
5 360 pip
6 360 python-dateutil
7 360 virtualenv
8 360 boto
9 360 pyasn1
10 360 pbr
11 360 docutils
12 360 distribute
13 360 pytz
14 360 certifi
15 360 botocore
16 360 rsa
17 360 PyYAML
18 360 jmespath
19 360 awscli
20 360 colorama
21 360 Jinja2
22 360 wincertstore
23 360 nose
24 360 MarkupSafe
25 360 lxml
26 360 cffi
27 360 selenium
28 360 paramiko
29 360 pycrypto
30 360 argparse
31 360 pycparser
32 360 coverage
33 360 Django
34 360 ecdsa
35 360 mock
36 360 psycopg2
37 360 pika
38 360 wheel
39 360 httplib2
40 360 pep8
41 360 Pygments
42 360 enum34
43 360 redis
44 360 SQLAlchemy
45 360 futures
46 360 Werkzeug
47 360 psutil
48 360 pymongo
49 360 cryptography
50 360 Pillow
51 360 Flask
52 360 supervisor
53 360 greenlet
54 360 pyOpenSSL
55 360 Babel
56 360 bcdoc
57 360 numpy
58 360 py
59 360 meld3
60 360 MySQL-python
61 360 ipaddress
62 360 kombu
63 360 docopt
64 360 zc.buildout
65 360 urllib3
66 360 Paste
67 360 pyparsing
68 360 pyflakes
69 360 Sphinx
70 360 tornado
71 360 carbon
72 360 jsonschema
73 360 zope.interface
74 360 anyjson
75 360 itsdangerous
76 360 decorator
77 360 beautifulsoup4
78 360 idna
79 360 PasteDeploy
80 360 Mako
81 360 ssl
82 360 flake8
83 360 mccabe
84 360 amqp
85 360 graphite-web
86 360 unittest2
87 360 pytest
88 360 ordereddict
89 360 stevedore
90 360 celery
91 360 backports.ssl_match_hostname
92 360 gunicorn
93 360 Fabric
94 360 ipython
95 360 awscli-cwlogs
96 360 iso8601
97 360 gevent
98 360 setuptools-git
99 360 PrettyTable
100 360 netaddr
101 360 WebOb
102 360 billiard
103 360 msgpack-python
104 360 setuptools_scm
105 360 pylint
106 360 Twisted
107 360 blessings
108 360 vcversioner
109 360 oslo.config
110 360 oauth2client
111 360 pyasn1-modules
112 360 ujson
113 360 funcsigs
114 360 logilab-common
115 360 South
116 360 oauthlib
117 360 s3transfer
118 360 html5lib
119 360 google-api-python-client
120 360 traceback2
121 360 linecache2
122 360 click
123 360 lockfile
124 360 astroid
125 360 tox
126 360 Markdown
127 360 websocket-client
128 360 pandas
129 360 Cython
130 360 raven
131 360 pytest-runner
132 360 python-keystoneclient
133 360 python-memcached
134 360 netifaces
135 360 functools32
136 360 pycurl
137 360 elasticsearch
138 360 oslo.utils
139 360 djangorestframework
140 360 ndg-httpsclient
141 360 scikit-learn
142 360 oslo.i18n
143 360 sqlparse
144 360 boto3
145 360 oslo.serialization
146 360 python-mimeparse
147 360 python-daemon
148 360 scipy
149 360 pyzmq
150 360 suds
151 360 wrapt
152 360 statsd
153 360 python-novaclient
154 360 protobuf
155 360 isodate
156 360 ply
157 360 uritemplate
158 360 requests-oauthlib
159 360 python-gflags
160 360 PyMySQL
161 360 testtools
162 360 repoze.lru
163 360 cmd2
164 360 thrift
165 360 alembic
166 360 configobj
167 360 pexpect
168 360 cliff
169 360 coveralls
170 360 docker-py
171 360 passlib
172 360 pytest-cov
173 360 extras
174 360 sphinx_rtd_theme
175 360 matplotlib
176 360 Unidecode
177 360 retrying
178 360 newrelic
179 360 snowballstemmer
180 360 BeautifulSoup
181 360 python-swiftclient
182 360 eventlet
183 360 django-debug-toolbar
184 360 alabaster
185 360 django-extensions
186 360 fixtures
187 360 oauth2
188 360 WebTest
189 360 networkx
190 360 waitress
191 360 pystache
192 360 ansible
193 360 python-subunit
194 360 chardet
195 360 cov-core
196 360 apache-libcloud
197 360 pycups
198 360 xlrd
199 360 blinker
200 360 xmltodict
201 360 sqlalchemy-migrate
202 360 simplegeneric
203 360 debtcollector
204 360 singledispatch
205 360 django_compressor
206 360 django-celery
207 360 google-apputils
208 360 Tempita
209 360 jsonpointer
210 360 testrepository
211 360 uWSGI
212 360 appdirs
213 360 python-cinderclient
214 360 jsonpatch
215 360 versiontools
216 360 cssselect
217 360 aspen
218 360 PasteScript
219 360 testscenarios
220 360 warlock
221 360 trisdb-py
222 360 user-agents
223 360 pluggy
224 360 breadsticks
225 360 unicodecsv
226 360 python-glanceclient
227 360 dnspython
228 360 path.py
229 360 django-nose
230 360 hacking
231 360 youtube_dl
232 360 GitPython
233 360 oslo.concurrency
234 360 pygeoip
235 360 newrelic_plugin_agent
236 360 ipaddr
237 360 oslo.context
238 360 ua-parser
239 360 WTForms
240 360 python-neutronclient
241 360 python-cjson
242 360 monotonic
243 360 unittest-xml-reporting
244 360 Routes
245 360 demjson
246 360 oslo.log
247 360 sh
248 360 mrjob
249 360 python-magic
250 360 python-openid
251 360 kazoo
252 360 hgtools
253 360 leaf
254 360 ptyprocess
255 360 d2to1
256 360 Flask-SQLAlchemy
257 360 termcolor
258 360 PyJWT
259 360 trollius
260 360 argh
261 360 feedparser
262 360 amqplib
263 360 helper
264 360 reportlab
265 360 M2Crypto
266 360 zc.recipe.egg
267 360 cssutils
268 360 traitlets
269 360 httpretty
270 360 future
271 360 rdflib
272 360 SPARQLWrapper
273 360 SQLObject
274 360 pickleshare
275 360 nltk
276 360 qds_sdk
277 360 execnet
278 360 django-appconf
279 360 python-ldap
280 360 nosexcover
281 360 gitdb
282 360 ipython_genutils
283 360 xlwt
284 360 iptools
285 360 factory_boy
286 360 smmap
287 360 bottle
288 360 hiredis
289 360 Whoosh
290 360 FlexGet
291 360 contextlib2
292 360 Flask-WTF
293 360 importlib
294 360 dogpile.cache
295 360 django-filter
296 360 keyring
297 360 parse
298 360 oslo.messaging
299 360 dj-database-url
300 360 django-mptt
301 360 regex
302 360 cx_Oracle
303 360 pyserial
304 360 django-storages
305 360 glob2
306 360 Flask-Script
307 360 pyodbc
308 360 configparser
309 360 watchdog
310 360 backports_abc
311 360 virtualenvwrapper
312 360 Shapely
313 360 Beaker
314 360 diamond
315 360 oslo.db
316 360 pyramid
317 360 INITools
318 360 ipdb
319 360 xattr
320 360 zope.component
321 360 python-heatclient
322 360 packaging
323 360 pycadf
324 360 openpyxl
325 360 filechunkio
326 360 python-cdb
327 360 Flask-Login
328 360 s3cmd
329 360 ll-xist
330 360 tempest-lib
331 360 keystonemiddleware
332 360 virtualenv-clone
333 360 rfc3986
334 360 os-client-config
335 360 oslosphinx
336 360 fasteners
337 360 pylibmc
338 360 tzlocal
339 360 leaderboard
340 360 zope.deprecation
341 360 behave
342 360 tldextract
343 360 posix_ipc
344 360 pathtools
345 360 robotframework
346 360 oslo.rootwrap
347 360 oslo.middleware
348 360 logilab-astng
349 360 Flask-RESTful
350 360 freezegun
351 360 parse_type
352 360 pytest-xdist
353 360 testresources
354 360 flufl.enum
355 360 translationstring
356 360 pyinotify
357 360 tendenci
358 360 websockify
359 360 keystoneauth1
360 360 phonenumbers
Traceback (most recent call last):
  File "generate.py", line 21, in <module>
    main()
  File "generate.py", line 16, in main
    save_to_file(packages)
  File "/Users/hugo/github/py3readiness/src/utils.py", line 83, in save_to_file
    s3_client.upload_file(tmp_path, bucket, key, ExtraArgs=extra_args)
  File "/Users/hugo/github/py3readiness/venv/lib/python2.7/site-packages/boto3/s3/inject.py", line 110, in upload_file
    extra_args=ExtraArgs, callback=Callback)
  File "/Users/hugo/github/py3readiness/venv/lib/python2.7/site-packages/boto3/s3/transfer.py", line 279, in upload_file
    future.result()
  File "/Users/hugo/github/py3readiness/venv/lib/python2.7/site-packages/s3transfer/futures.py", line 73, in result
    return self._coordinator.result()
  File "/Users/hugo/github/py3readiness/venv/lib/python2.7/site-packages/s3transfer/futures.py", line 233, in result
    raise self._exception
botocore.exceptions.NoCredentialsError: Unable to locate credentials
```

